### PR TITLE
Add bazel build files for ovh and gopkg/ini.v1

### DIFF
--- a/vendor/github.com/ovh/go-ovh/ovh/BUILD.bazel
+++ b/vendor/github.com/ovh/go-ovh/ovh/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "configuration.go",
+        "consumer_key.go",
+        "error.go",
+        "logger.go",
+        "ovh.go",
+    ],
+    importmap = "github.com/jetstack/cert-manager/vendor/github.com/ovh/go-ovh/ovh",
+    importpath = "github.com/ovh/go-ovh/ovh",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/gopkg.in/ini.v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "configuration_test.go",
+        "consumer_key_test.go",
+        "error_test.go",
+        "ovh_test.go",
+    ],
+    embed = [":go_default_library"],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/gopkg.in/ini.v1/BUILD.bazel
+++ b/vendor/gopkg.in/ini.v1/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "error.go",
+        "file.go",
+        "ini.go",
+        "key.go",
+        "parser.go",
+        "section.go",
+        "struct.go",
+    ],
+    importmap = "github.com/jetstack/cert-manager/vendor/gopkg.in/ini.v1",
+    importpath = "gopkg.in/ini.v1",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "bench_test.go",
+        "file_test.go",
+        "ini_internal_test.go",
+        "init_test.go",
+        "key_test.go",
+        "parser_test.go",
+        "section_test.go",
+        "struct_test.go",
+    ],
+    embed = [":go_default_library"],
+    tags = ["manual"],
+    deps = ["//vendor/gopkg.in/check.v1:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Signed-off-by: Vincent Hurtevent <vincent.hurtevent@pc-scol.fr>

**What this PR does / why we need it**:
Add BUILD.bazel files for OVH DNS provider dependencies.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
